### PR TITLE
Add EF Core packages for database functionality

### DIFF
--- a/MaintenancePortal/MaintenancePortal.csproj
+++ b/MaintenancePortal/MaintenancePortal.csproj
@@ -6,4 +6,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes #14

Added `Microsoft.EntityFrameworkCore` (v9.0.10) for core ORM features. Added `Microsoft.EntityFrameworkCore.SqlServer` (v9.0.10) for SQL Server support. Added `Microsoft.EntityFrameworkCore.Tools` (v9.0.10) for design-time tools, with `<PrivateAssets>` set to `all` and `<IncludeAssets>` configured for build/runtime assets.