### PR TITLE
Use connection string from appsettings.json in DbContext

### DIFF
--- a/MaintenancePortal/Data/AppDbContextFactory.cs
+++ b/MaintenancePortal/Data/AppDbContextFactory.cs
@@ -7,8 +7,18 @@ public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
 {
     public AppDbContext CreateDbContext(string[] args)
     {
+        // Build configuration to read connection string from appsettings.json
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        // Get connection string
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+
+        // Configure DbContextOptions with SQL Server provider
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
-        optionsBuilder.UseSqlServer();
+        optionsBuilder.UseSqlServer(connectionString);
 
         return new AppDbContext(optionsBuilder.Options);
     }


### PR DESCRIPTION
Closes #42 
Updated `AppDbContextFactory` to dynamically retrieve the connection string from `appsettings.json` using a
`ConfigurationBuilder`. The connection string is now passed to `UseSqlServer` in `DbContextOptionsBuilder`, replacing the previous parameterless call. This ensures the database connection is configured explicitly and aligns with the application's configuration settings.