### PR TITLE
Update DefaultConnection string in appsettings.json

### DIFF
--- a/MaintenancePortal/appsettings.json
+++ b/MaintenancePortal/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=MaintenancePortalDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=MaintenancePortalDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
   }
 }


### PR DESCRIPTION
Closes #41 
Revised the `DefaultConnection` string in the `ConnectionStrings` section of `appsettings.json` to use `(localdb)\MSSQLLocalDB` instead of `localhost`. Added additional parameters such as `Connect Timeout`, `Encrypt`, `Trust Server Certificate`, `Application Intent`, and `Multi Subnet Failover` to enhance configuration specificity and adapt to a new environment.