### PR TITLE
Add explicit value to RememberMe checkbox in Login.cshtml

### DIFF
--- a/MaintenancePortal/Views/User/Login.cshtml
+++ b/MaintenancePortal/Views/User/Login.cshtml
@@ -18,7 +18,7 @@
                     <span asp-validation-for="Password" class="text-danger"></span>
                 </div>
                 <div class="form-check mb-4">
-                    <input type="checkbox" id="RememberMe" name="RememberMe" class="form-check-input" />
+                    <input type="checkbox" id="RememberMe" name="RememberMe" class="form-check-input" value="true"/>
                     <label for="RememberMe" class="form-check-label">Remember Me</label>
                 </div>
                 <button type="submit" class="btn btn-primary w-100">Login</button>


### PR DESCRIPTION
Closes #82
The `RememberMe` checkbox input was updated to include a `value="true"` attribute. This ensures that the checkbox explicitly sends the value "true" when selected, improving clarity and reliability for backend processing or form submission handling.