### PR TITLE
Enable cookie auth and add startup DB seeding for roles/user

### DIFF
--- a/MaintenancePortal/Program.cs
+++ b/MaintenancePortal/Program.cs
@@ -1,5 +1,6 @@
 using MaintenancePortal.Data;
 using MaintenancePortal.Models;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,6 +8,19 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+
+// Configure cookie-based authentication
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        options.ExpireTimeSpan = TimeSpan.FromDays(14);
+        options.SlidingExpiration = true;
+        options.LoginPath = "/User/Login"; // Redirect to this path if not authenticated
+        options.LoginPath = "/User/Login"; // Redirect to this path if not authenticated
+        //options.AccessDeniedPath = "/User/AccessDenied"; // Redirect to this path if access is denied
+    });
 
 // Register AppDbContext with ASP.NET Core DI container
 // Connect to SQL Server using "DefaultConnection" from appsettings.json
@@ -23,6 +37,16 @@ builder.Services.AddIdentity<User, IdentityRole>()
 
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    var userManager = services.GetRequiredService<UserManager<User>>();
+    var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
+
+    // Call the seed method
+    await SeedDatabase(userManager, roleManager);
+}
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
@@ -47,3 +71,35 @@ app.MapControllerRoute(
 
 
 app.Run();
+
+async Task SeedDatabase(UserManager<User> userManager, RoleManager<IdentityRole> roleManager)
+{
+    // Seed default roles
+    string[] roleNames = { "Admin", "User" };
+    foreach (var roleName in roleNames)
+    {
+        var roleExist = await roleManager.RoleExistsAsync(roleName);
+        if (!roleExist)
+        {
+            await roleManager.CreateAsync(new IdentityRole(roleName));
+        }
+    }
+
+    // Seed a default admin user
+    var defaultUser = await userManager.FindByEmailAsync("admin@example.com");
+    if (defaultUser == null)
+    {
+        defaultUser = new User
+        {
+            UserName = "admin",
+            Email = "admin@example.com",
+            FirstName = "Admin",
+            LastName = "User"
+        };
+        var result = await userManager.CreateAsync(defaultUser, "Admin@1234");
+        if (result.Succeeded)
+        {
+            await userManager.AddToRoleAsync(defaultUser, "Admin");
+        }
+    }
+}


### PR DESCRIPTION
Closes #89
Configured secure cookie-based authentication with login path and sliding expiration. Added database seeding at startup to ensure default roles ("Admin", "User") and create a default admin user if missing.